### PR TITLE
[pam] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/pam.spec
+++ b/rpm/pam.spec
@@ -73,6 +73,7 @@ BuildRequires: autoconf >= 2.60
 BuildRequires: automake, libtool
 BuildRequires: bison, flex, sed
 BuildRequires: perl, pkgconfig, gettext-devel
+BuildRequires: pkgconfig(libcrypt)
 Requires: glibc >= 2.3.90-37
 BuildRequires: db4-devel
 # Systemd pam library need to be installed on right folder


### PR DESCRIPTION
pam depdends on pkconfig(libcrypt) but it was not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.